### PR TITLE
Homework 10: Products subcategories routing

### DIFF
--- a/src/app/components/sidenav/categories-select/categories-select.component.html
+++ b/src/app/components/sidenav/categories-select/categories-select.component.html
@@ -12,6 +12,8 @@
                 mat-button
                 hideToggle
                 class="sub-catigory"
+                [routerLink]="['/', 'products-list']"
+                [queryParams]="{subCategoryId: subCategory._id}"
             >
                 {{ subCategory.name }}
             </button>

--- a/src/app/components/sidenav/categories-select/categories-select.component.ts
+++ b/src/app/components/sidenav/categories-select/categories-select.component.ts
@@ -2,6 +2,7 @@ import {ChangeDetectionStrategy, Component, input} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {MatButtonModule} from '@angular/material/button';
 import {MatExpansionModule} from '@angular/material/expansion';
+import {RouterLink} from '@angular/router';
 import {Category} from '../../../shared/categories/category.interface';
 
 @Component({
@@ -10,7 +11,7 @@ import {Category} from '../../../shared/categories/category.interface';
     styleUrls: ['./categories-select.component.less'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [CommonModule, MatButtonModule, MatExpansionModule],
+    imports: [CommonModule, MatButtonModule, MatExpansionModule, RouterLink],
 })
 export class CategoriesSelectComponent {
     categories = input.required<Category[] | null>();

--- a/src/app/pages/products-list/products-list.component.ts
+++ b/src/app/pages/products-list/products-list.component.ts
@@ -1,6 +1,7 @@
 import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
 import {CommonModule} from '@angular/common';
-import {Router, RouterLink} from '@angular/router';
+import {Router, RouterLink, ActivatedRoute} from '@angular/router';
+import {map} from 'rxjs/operators';
 import {CardComponent} from './card/card.component';
 import {ScrollWithLoadingDirective} from '../../shared/scroll-with-loading/scroll-with-loading.directive';
 import {ProductsStoreService} from '../../shared/products/products-store.service';
@@ -23,10 +24,17 @@ import {FilterByPropertyPipe} from '../../shared/filter-by-property/filter-by-pr
 export class ProductsListComponent {
     private readonly productsStoreService = inject(ProductsStoreService);
     private readonly router = inject(Router);
+    private readonly activatedRoute = inject(ActivatedRoute);
 
     readonly products = this.productsStoreService.products;
 
     constructor() {
-        this.productsStoreService.loadProducts();
+        this.subscribeToSubCategoryIdChanges();
+    }
+
+    subscribeToSubCategoryIdChanges(): void {
+        this.activatedRoute.queryParamMap
+            .pipe(map(queryParams => queryParams.get('subCategoryId')))
+            .subscribe(subCategoryId => this.productsStoreService.loadProducts(subCategoryId));
     }
 }

--- a/src/app/shared/products/products-store.service.ts
+++ b/src/app/shared/products/products-store.service.ts
@@ -13,13 +13,13 @@ export class ProductsStoreService {
     readonly products = signal<Product[] | null>(null);
     readonly currentProduct = signal<Product | null>(null);
 
-    loadProducts(): void {
+    loadProducts(subCategoryId: string | null): void {
         if (this.loadProductsSubscription) {
             this.loadProductsSubscription.unsubscribe();
         }
 
         this.loadProductsSubscription = this.productsApiService
-            .getProducts$()
+            .getProducts$(subCategoryId)
             .subscribe(products => {
                 this.products.set(products);
 


### PR DESCRIPTION
Реализовал роутинг с одним конфигом в `routes`, как указано в задании. Использовал для этого query-параметр, вместо отдельного сегмента.

Страница со списком товаров открывается в таком случае при таких url'ах:
- `/products-list`;
- `/products-list?subCategoryId=category-name`.